### PR TITLE
Fix bracket on Maya's bio

### DIFF
--- a/source/bios/_maya-benari.md
+++ b/source/bios/_maya-benari.md
@@ -1,7 +1,7 @@
 Maya Benari is a designer and front-end developer at [18F][], a digital 
 services team within the federal government. She works on the [Draft U.S. Web Design Standards][standards], which are available to the public and promote 
 consistent, cohesive federal websites. Maya previously fed her civic design 
-passion as a fellow at [Code for America][code[. She is a featured voice in 
+passion as a fellow at [Code for America][code]. She is a featured voice in 
 [net magazine][net] and will appear in the upcoming O'Reilly book "[Tragic 
 Design][tragic]."
 


### PR DESCRIPTION
The bracket was reversed, so I switched it back.